### PR TITLE
fix(solc): metadata explicit disable

### DIFF
--- a/config.js
+++ b/config.js
@@ -264,6 +264,9 @@ function hardhat(userSettings) {
                 {
                     version: "0.6.12",
                     settings: {
+                          metadata: {
+                             bytecodeHash: "none",
+                          },
                         optimizer: {
                             enabled: true,
                             runs: 200,


### PR DESCRIPTION
### solidity compiler config
Explicitly disable 'bytecodeHash' generation as this is machine-dependent. Disabling this makes deployments/generation processes more deterministic (and thus reproducible).

[docs.soliditylang.org/en/v0.6.12/metadata.html](https://docs.soliditylang.org/en/v0.6.12/metadata.html)

```js
  solidity: {
    version: "0.6.12",
    settings: {
      metadata: {
        bytecodeHash: "none",
      },
```

> NOTE: additionally for what its worth, the `optimizer: enabled` flag is depreciated